### PR TITLE
Relish fails to load when there is no HOME variable set.

### DIFF
--- a/lib/relish.rb
+++ b/lib/relish.rb
@@ -7,14 +7,14 @@ module Relish
       attr_writer name
       class_eval %{
         def #{name}                              # def global_options_file
-          @#{name.to_s} ||=                      #   @global_options_file ||= 
-            ENV['RELISH_#{name.to_s.upcase}'] || #   ENV['RELISH_GLOBAL_OPTIONS_FILE'] || 
+          @#{name.to_s} ||=                      #   @global_options_file ||=
+            ENV['RELISH_#{name.to_s.upcase}'] || #   ENV['RELISH_GLOBAL_OPTIONS_FILE'] ||
             '#{value}'                           #   '~/.relish'
         end                                      # end
       }
     end
 
-    setting :global_options_file, File.join(File.expand_path('~'), '.relish')
+    setting :global_options_file, File.join(File.expand_path('~'), '.relish') rescue "~/.relish"
     setting :local_options_file,  '.relish'
     setting :default_host,        'api.relishapp.com'
     setting :default_ssl,         'on'


### PR DESCRIPTION
When executing relish under a CI environment without the HOME variable
set (centos in this case) relish will crash with this error:

NOTE: There aren't any tests for this because I simply couldn't work out a way to test this.
Also, it might not be obvious but it's the actual call to File.expand_path("~") that's causing the crash.

```
/relish-0.5.1/lib/relish.rb:17:in
`expand_path': couldn't find HOME environment -- expanding `~'
(ArgumentError)
  from
/relish-0.5.1/lib/relish.rb:17
  from
/relish-0.5.1/lib/relish/command.rb:1:in
`require'
  from
/relish-0.5.1/lib/relish/command.rb:1
  from
/relish-0.5.1/bin/relish:5:in
`require'
  from
/relish-0.5.1/bin/relish:5
  from
/bin/relish:19:in
`load'
  from
/bin/relish:19
```
