### PR TITLE
Include features/.nav in files to be sent.

### DIFF
--- a/lib/relish/commands/push.rb
+++ b/lib/relish/commands/push.rb
@@ -69,6 +69,7 @@ module Relish
 
       def files
         Dir["#{path}/**/*.{feature,md,markdown}"] +
+        Dir["#{path}/.nav"] +
         Dir["#{path}/**/.nav"]
       end
 
@@ -77,4 +78,3 @@ module Relish
 
   end
 end
-


### PR DESCRIPTION
I noticed that `features/.nav` wasn't being included in the list of files printed after we do a push. It seems that the `#{path}/**/.nav` glob only searches for `.nav` in subdirectories of `features`. This small change fixes it.
