### PR TITLE
Replace 'archive-tar-minitar' with 'minitar'

### DIFF
--- a/lib/relish/commands/push.rb
+++ b/lib/relish/commands/push.rb
@@ -1,5 +1,5 @@
 require 'zlib'
-require 'archive/tar/minitar'
+require 'minitar'
 require 'stringio'
 require 'rest_client'
 
@@ -57,9 +57,9 @@ module Relish
         stream = StringIO.new
         begin
           tgz = Zlib::GzipWriter.new(stream)
-          tar = Archive::Tar::Minitar::Output.new(tgz)
+          tar = Minitar::Output.new(tgz)
           files.each do |entry|
-            Archive::Tar::Minitar.pack_file(entry, tar)
+            Minitar.pack_file(entry, tar)
           end
         ensure
           tar.close if tar # Closes both tar and tgz.

--- a/relish.gemspec
+++ b/relish.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   {
-    'archive-tar-minitar' => '>= 0.5.2',
+    'minitar' => '>= 0.5.2',
     'rest-client'         => '>= 1.7.2',
     'json'                => '>= 1.4.6'
   }.each do |lib, version|


### PR DESCRIPTION
After installing the `relish` gem today, I noticed that the `archive-tar-minitar` dependency printed the following deprecation warning:

```
'archive-tar-minitar' has been deprecated; just install 'minitar'.
```

This replaces the `archive-tar-minitar` dependency with the recommended `minitar` gem. See: https://github.com/halostatue/minitar#description.